### PR TITLE
Support multiple 【】s on the same line

### DIFF
--- a/syntaxes/dongbei.tmLanguage.json
+++ b/syntaxes/dongbei.tmLanguage.json
@@ -34,7 +34,7 @@
 		"variables":{
 			"patterns":[{
 				"name": "support.variable",
-				"match": "【.*】"
+				"match": "【.*?】"
 			}]
 		},
 		"operators": {


### PR DESCRIPTION
以前：

【老王】装【老张】

会被渲染成一个变量名，因为 .* 是 greedy 的。

.*? 是最短 match